### PR TITLE
[DEV-15861] Emit a signal any time is_active is called

### DIFF
--- a/gargoyle/manager.py
+++ b/gargoyle/manager.py
@@ -8,6 +8,7 @@ from django.utils.functional import SimpleLazyObject
 from modeldict import ModelDict
 
 from gargoyle.proxy import SwitchProxy
+from gargoyle.signals import key_is_active_checked
 
 from .constants import DISABLED, EXCLUDE, GLOBAL, INCLUDE, INHERIT, SELECTIVE
 
@@ -44,6 +45,8 @@ class SwitchManager(ModelDict):
         >>> gargoyle.is_active('my_feature', request)
         """
         default = kwargs.pop('default', False)
+
+        key_is_active_checked.send(sender=self, key=key)
 
         # Check all parents for a disabled state
         parts = key.split(':')

--- a/gargoyle/signals.py
+++ b/gargoyle/signals.py
@@ -69,3 +69,14 @@ switch_condition_added = django.dispatch.Signal(providing_args=["request", "swit
 #:      from gargoyle.signals import switch_condition_deleted
 #:      switch_condition_deleted.connect(switch_condition_deleted_callback)
 switch_condition_removed = django.dispatch.Signal(providing_args=["request", "switch", "condition"])
+
+#: This signal is sent when a key is checked for being active.
+#:
+#: Example subscriber::
+#:
+#:      def key_is_active_checked_callback(sender, key, **extra):
+#:          logging.debug('is_active called for key: %s', key)
+#:
+#:      from gargoyle.signals import key_is_active_checked
+#:      key_is_active_checked.connect(key_is_active_checked_callback)
+key_is_active_checked = django.dispatch.Signal(providing_args=["key"])


### PR DESCRIPTION
Tests run fine, there are none for the existing signals and Gargoyle doesn't even bring in `mock` as a dependency so it's pretty difficult to even try to write a test for this.

Once this ships we'll hook into it on the webapp side to emit a `statsd` metric tagged with the flag name. After a day or so of requests we should have enough data to determine which flags are no longer actually being accessed.