### PR TITLE
[DEV-15633] Pass in max local timeout jitter to modeldict

### DIFF
--- a/gargoyle/manager.py
+++ b/gargoyle/manager.py
@@ -165,6 +165,8 @@ def make_gargoyle():
         kwargs['cache'] = caches[settings.GARGOYLE_CACHE_NAME]
     if hasattr(settings, 'GARGOYLE_REMOTE_CACHE_TIMEOUT'):
         kwargs['remote_timeout'] = settings.GARGOYLE_REMOTE_CACHE_TIMEOUT
+    if hasattr(settings, 'GARGOYLE_MAX_LOCAL_TIMEOUT_JITTER'):
+        kwargs['max_local_timeout_jitter'] = settings.GARGOYLE_MAX_LOCAL_TIMEOUT_JITTER
 
     return SwitchManager(Switch, **kwargs)
 


### PR DESCRIPTION
Once this ships we'll bump the versions in the webapp and use this new parameter to try to jitter the cache stampede.