### PR TITLE
[DEV-24703] Allow cache timeout to be configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ htmlcov
 .mr.developer.cfg
 .project
 .pydevproject
+.idea
 
 # Complexity
 output/*.html

--- a/gargoyle/manager.py
+++ b/gargoyle/manager.py
@@ -170,6 +170,8 @@ def make_gargoyle():
         kwargs['remote_timeout'] = settings.GARGOYLE_REMOTE_CACHE_TIMEOUT
     if hasattr(settings, 'GARGOYLE_MAX_LOCAL_TIMEOUT_JITTER'):
         kwargs['max_local_timeout_jitter'] = settings.GARGOYLE_MAX_LOCAL_TIMEOUT_JITTER
+    if hasattr(settings, 'GARGOYLE_LOCAL_CACHE_TIMEOUT'):
+        kwargs['timeout'] = settings.GARGOYLE_LOCAL_CACHE_TIMEOUT
 
     return SwitchManager(Switch, **kwargs)
 


### PR DESCRIPTION
Gargoyle flags are backed by two caches and the database. With our current settings (timeout = 30 and jitter = 120), entries in the the first cache (in-memory) can have stale entries up to 2.5 minutes old.  This makes it so that a developer testing codepaths that are behind a gargoyle flag exhibit "lagging" behavior.

This change allows us to specify the local cache's timeout via django settings and reduce the amount of lagging behavior.
