### PR TITLE
[DEV-102450] make Percent field is_active check exclude the upper bound

### DIFF
--- a/gargoyle/conditions.py
+++ b/gargoyle/conditions.py
@@ -141,7 +141,7 @@ class Percent(Range):
     def is_active(self, condition, value):
         condition = list(map(int, condition.split('-')))
         mod = value % 100
-        return mod >= condition[0] and mod <= condition[1]
+        return condition[0] <= mod < condition[1]
 
     def display(self, value):
         value = value.split('-')

--- a/tests/testapp/test_conditions.py
+++ b/tests/testapp/test_conditions.py
@@ -110,6 +110,41 @@ class PercentTests(TestCase):
         with pytest.raises(ValidationError):
             condition.clean('80-20')
 
+    def test_is_active_range_is_inclusive_on_lower_bound_and_exclusive_on_upper_bound(self):
+        condition = Percent()
+
+        # 0-10 should only be True for value % 100 < 10
+        assert condition.is_active('0-10', 0)
+        assert condition.is_active('0-10', 9)
+        assert not condition.is_active('0-10', 10)
+        assert not condition.is_active('0-10', 99)
+        assert condition.is_active('0-10', 100)
+        assert condition.is_active('0-10', 109)
+        assert not condition.is_active('0-10', 110)
+
+        # 90-100 should only be True for value % 100 >= 90
+        assert not condition.is_active('90-100', 0)
+        assert not condition.is_active('90-100', 89)
+        assert condition.is_active('90-100', 90)
+        assert condition.is_active('90-100', 99)
+        assert not condition.is_active('90-100', 100)
+        assert not condition.is_active('90-100', 189)
+        assert condition.is_active('90-100', 190)
+
+    def test_is_active_for_float_values(self):
+        condition = Percent()
+        assert not condition.is_active('10-20', 9.9999)
+        assert condition.is_active('10-20', 10.0)
+        assert condition.is_active('10-20', 10.0001)
+        assert condition.is_active('10-20', 19.9999)
+        assert not condition.is_active('10-20', 20.0)
+        assert not condition.is_active('10-20', 20.0001)
+        assert not condition.is_active('10-20', 99.9999)
+        assert not condition.is_active('10-20', 100.0)
+        assert not condition.is_active('10-20', 109.9999)
+        assert condition.is_active('10-20', 110.0)
+        assert condition.is_active('10-20', 110.0001)
+
 
 class AbstractDateTests(TestCase):
     def test_clean_success(self):


### PR DESCRIPTION
When specifying a range for a Percent condition in Gargoyle, it shows as if the percent doesn’t include the upper bound, but in reality it’s included, so the displayed percentage is not the actual percentage being used. This is particularly incorrect when using int values.

E.g.: If you specify 0-10 as the range, the condition is shown as 10%, but this is actually 11%. The condition will be active for values where its modulo 100 is 0 up to 10 inclusive, and inactive for 11 to 99. This means it’s active for 11 out of 100 possible values, and inactive for 89 out of 100 possible values.

This is because the check that is being done by this condition is:
```
mod = value % 100
return mod >= condition[0] and mod <= condition[1]
```

While it should be exclusive on the upper bound:
```
mod = value % 100
return mod >= condition[0] and mod < condition[1]
 ```

For float values the issue is not as big, since it’s basically just adding the exact upper bound to the active group, which basically doesn’t alter the percentage.