### PR TITLE
[DEV-102830] Switch `django.conf.urls.url()` to use `re_path()`

### DIFF
--- a/gargoyle/nexus_modules.py
+++ b/gargoyle/nexus_modules.py
@@ -13,8 +13,8 @@ from functools import wraps
 
 import nexus
 from django.conf import settings
-from django.conf.urls import url
 from django.http import HttpResponse, HttpResponseNotFound
+from django.urls import re_path
 
 from gargoyle import gargoyle, signals
 from gargoyle.conditions import ValidationError
@@ -68,13 +68,13 @@ class GargoyleModule(nexus.NexusModule):
 
     def get_urls(self):
         return [
-            url(r'^add/$', self.as_view(self.add), name='add'),
-            url(r'^update/$', self.as_view(self.update), name='update'),
-            url(r'^delete/$', self.as_view(self.delete), name='delete'),
-            url(r'^status/$', self.as_view(self.status), name='status'),
-            url(r'^conditions/add/$', self.as_view(self.add_condition), name='add-condition'),
-            url(r'^conditions/remove/$', self.as_view(self.remove_condition), name='remove-condition'),
-            url(r'^$', self.as_view(self.index), name='index'),
+            re_path(r'^add/$', self.as_view(self.add), name='add'),
+            re_path(r'^update/$', self.as_view(self.update), name='update'),
+            re_path(r'^delete/$', self.as_view(self.delete), name='delete'),
+            re_path(r'^status/$', self.as_view(self.status), name='status'),
+            re_path(r'^conditions/add/$', self.as_view(self.add_condition), name='add-condition'),
+            re_path(r'^conditions/remove/$', self.as_view(self.remove_condition), name='remove-condition'),
+            re_path(r'^$', self.as_view(self.index), name='index'),
         ]
 
     def render_on_dashboard(self, request):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -6,9 +6,10 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import nexus
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.contrib import admin
 from django.http import HttpResponse
+from django.urls import re_path
 from django.views.generic.base import RedirectView
 
 from gargoyle.compat import subinclude
@@ -17,8 +18,8 @@ admin.autodiscover()
 nexus.autodiscover()
 
 urlpatterns = [
-    url(r'^nexus/', include(nexus.site.urls)),
-    url(r'^admin/', subinclude(admin.site.urls)),
-    url(r'^foo/$', lambda request: HttpResponse(), name='gargoyle_test_foo'),
-    url(r'^/?$', RedirectView.as_view(url='/nexus/', permanent=False)),
+    re_path(r'^nexus/', include(nexus.site.urls)),
+    re_path(r'^admin/', subinclude(admin.site.urls)),
+    re_path(r'^foo/$', lambda request: HttpResponse(), name='gargoyle_test_foo'),
+    re_path(r'^/?$', RedirectView.as_view(url='/nexus/', permanent=False)),
 ]


### PR DESCRIPTION
# What is the reason for this pull request?
This PR replaces the deprecated `url` function with `re_path`.

# Code Review Instructions
## Acceptance tests
- Check that the function calls are correctly replaced.
- Run the test suite with `tox -e py38-django32` and verify that no warnings related to `url` and `re_path` are raised.