### PR TITLE
[DEV-102832] Replace `ugettext_lazy` with `gettext_lazy`

### DIFF
--- a/gargoyle/models.py
+++ b/gargoyle/models.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from django.conf import settings
 from django.db import models
 from django.utils.timezone import now
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from jsonfield import JSONField
 
 from .constants import DISABLED, EXCLUDE, GLOBAL, INCLUDE, INHERIT, SELECTIVE


### PR DESCRIPTION
# What is the reason for this pull request?
This PR replaces the deprecated `ugettext_lazy` function with `gettext_lazy`

# Code Review Instructions
## Acceptance tests
- Check that the function is replaced in the whole repo.
- Run the test suite with `tox -e py38-django32` and verify that no warnings related to `ugettext_lazy` are raised.