### PR TITLE
[DEV-102833] Remove `default_app_config`

### DIFF
--- a/gargoyle/__init__.py
+++ b/gargoyle/__init__.py
@@ -17,8 +17,6 @@ VERSION = __version__  # old version compat
 
 __all__ = ('gargoyle', 'autodiscover', '__version__', 'VERSION')
 
-default_app_config = 'gargoyle.apps.GargoyleAppConfig'
-
 
 def autodiscover():
     """


### PR DESCRIPTION
# What is the reason for this pull request?
This PR removes the deprecated and unneeded `default_app_config` declaration in a Django app.

# Code Review Instructions
## Acceptance tests
- Run the test suite with `tox -e py38-django32` and verify that no warnings related to `default_app_config` are raised.