### PR TITLE
[DEV-103269] Upgrade the `nexus-yplan` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,5 +41,8 @@ sqlparse==0.4.4
     # via -r requirements.in
 black==24.1.1
 
+# Nexus
+https://github.com/roverdotcom/nexus/archive/3ec4808cf45b1c30e083f90ac1e33e9a3d0a7570.zip
+
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -39,14 +39,9 @@ setup(
     zip_safe=False,
     install_requires=[
         'django-modeldict-yplan>=1.5.0',
-        'nexus-yplan>=1.2.0',
+        'nexus-yplan@https://github.com/roverdotcom/nexus-django4.2/archive/41dfacf3127e2637a7aa9fab5157cb3dbf3120b3.zip',  # noqa: E501
         'jsonfield>=3.1.0',
     ],
-    extras_require={
-        ':python_version=="2.7"': [
-            'contextdecorator',
-        ]
-    },
     license='Apache License 2.0',
     include_package_data=True,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     zip_safe=False,
     install_requires=[
         'django-modeldict-yplan>=1.5.0',
-        'nexus-yplan@https://github.com/roverdotcom/nexus-django4.2/archive/41dfacf3127e2637a7aa9fab5157cb3dbf3120b3.zip',  # noqa: E501
+        'nexus-yplan@https://github.com/roverdotcom/nexus/archive/3ec4808cf45b1c30e083f90ac1e33e9a3d0a7570.zip',  # noqa: E501
         'jsonfield>=3.1.0',
     ],
     license='Apache License 2.0',

--- a/tests/testapp/test_builtins.py
+++ b/tests/testapp/test_builtins.py
@@ -183,7 +183,7 @@ class AppTodayConditionSetTests(TestCase):
     @override_settings(USE_TZ=True, TIME_ZONE="America/New_York")
     @timezone.override('Europe/Moscow')
     def test_use_tz_with_active(self):
-        with freeze_time(self.server_dt_aware, tz_offset=self.server_tz_offset):
+        with freeze_time(self.server_dt_aware):
             assert (
                 self.condition_set.get_field_value(None, 'now_is_on_or_after')
                 == self.server_dt + self.app_to_server_tz_offset
@@ -192,7 +192,7 @@ class AppTodayConditionSetTests(TestCase):
     @override_settings(USE_TZ=True, TIME_ZONE="America/New_York")
     @timezone.override(None)
     def test_use_tz_no_active(self):
-        with freeze_time(self.server_dt_aware, tz_offset=self.server_tz_offset):
+        with freeze_time(self.server_dt_aware):
             assert (
                 self.condition_set.get_field_value(None, 'now_is_on_or_after')
                 == self.server_dt + self.app_to_server_tz_offset
@@ -231,7 +231,7 @@ class ActiveTimezoneTodayConditionSetTests(TestCase):
     @override_settings(USE_TZ=True, TIME_ZONE="America/New_York")
     @timezone.override('Europe/Moscow')
     def test_use_tz_with_active(self):
-        with freeze_time(self.server_dt_aware, tz_offset=self.server_tz_offset):
+        with freeze_time(self.server_dt_aware):
             assert (
                 self.condition_set.get_field_value(None, 'now_is_on_or_after')
                 == self.server_dt + self.active_to_server_tz_offset
@@ -240,7 +240,7 @@ class ActiveTimezoneTodayConditionSetTests(TestCase):
     @override_settings(USE_TZ=True, TIME_ZONE="America/New_York")
     @timezone.override(None)
     def test_use_tz_no_active(self):
-        with freeze_time(self.server_dt_aware, tz_offset=self.server_tz_offset):
+        with freeze_time(self.server_dt_aware):
             assert (
                 self.condition_set.get_field_value(None, 'now_is_on_or_after')
                 == self.server_dt + self.app_to_server_tz_offset


### PR DESCRIPTION
This PR tweaks some tests that were failing in django 4 and above.

The issue was that django 4 changed the way the `django.utils.timezone.now` function works: [django 3 code](https://github.com/django/django/blob/stable/3.2.x/django/utils/timezone.py#L196) vs [django 4 code](https://github.com/django/django/blob/stable/4.2.x/django/utils/timezone.py#L235)

Both functions return the same value, but the way they do it is different. This wouldn't bother us, but given that the failing tests use `freezegun` and various combinations of timezones and offsets, the result was not the same in different django versions.

The key to solve this was looking at the `freeze_time` source code. Failing tests had time frozen with a `tz_offset` that was ignored by `freezegun` in django 3 (because `django.utils.timezone.now` calls `datetime.utcnow`, [source](https://github.com/spulec/freezegun/blob/1.1.0/freezegun/api.py#L407)), but it was taken into account in django 4 (because it calls `datetime.now` instead, [source](https://github.com/spulec/freezegun/blob/1.1.0/freezegun/api.py#L383))

At the end of the day, tests pass in every django version:
<img width="650" alt="image" src="https://github.com/roverdotcom/gargoyle/assets/17834064/ddf33220-8d06-45e8-a44d-3f75909b7592">
