### PR TITLE
[DEV-102835] [Optional] [DJANGO_5.0_LIBRARY_DEPRECATIONS] Remove `USE_L10N` in `gargoyle`

### DIFF
--- a/tests/settings/base.py
+++ b/tests/settings/base.py
@@ -48,7 +48,6 @@ ROOT_URLCONF = 'urls'
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True
-USE_L10N = True
 
 TEMPLATES = [
     {

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{38}-codestyle,
     py{38,39,310}-django{32,42}
+    py{310}-django{50}
 
 [testenv]
 setenv =
@@ -9,6 +10,7 @@ setenv =
 deps =
     django32: Django>=3.2,<4.0
     django42: Django>=4.2,<5.0
+    django50: Django>=5.0,<5.1
     -rrequirements.txt
 commands = python runtests.py {posargs}
 


### PR DESCRIPTION
# What is the reason for this pull request?
This PR removes the deprecated `USE_L10N` setting.

# Code Review Instructions
## Acceptance tests
- Run the test suite with `tox` and verify that no related warnings are raised.

Tox output:
<img width="638" alt="image" src="https://github.com/roverdotcom/gargoyle/assets/17834064/18452496-010e-42fe-8343-c5208544e226">
