### PR TITLE
[DEV-102834] [Optional] [DJANGO_5.0_LIBRARY_DEPRECATIONS] Migrate off of `pytz` to `zoneinfo` in `gargoyle`

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,9 +4,7 @@ freezegun>=1.1.0
 isort
 multilint
 Pygments
-pytz
 pytest
 pytest-cov
 pytest-django
-pytz
 sqlparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,8 +33,6 @@ pytest-django==4.8.0
     # via -r requirements.in
 python-dateutil==2.8.2
     # via freezegun
-pytz==2021.3
-    # via -r requirements.in
 six==1.10.0
     # via python-dateutil
 sqlparse==0.4.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ atomic = true
 honor_noqa = true
 remove_redundant_aliases = true
 known_first_party = gargoyle,testapp
-known_third_party = django,nexus,pytz
+known_third_party = django,nexus
 
 [tool:pytest]
 addopts = -p no:doctest

--- a/tests/testapp/test_builtins.py
+++ b/tests/testapp/test_builtins.py
@@ -3,7 +3,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime
 import socket
 
-import pytz
+try:
+    import zoneinfo
+except ImportError:
+    # For python 3.8
+    from backports import zoneinfo
+
 from django.test import RequestFactory, TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
@@ -134,8 +139,8 @@ class UTCTodayConditionSetTests(TestCase):
         """
         self.condition_set = UTCTodayConditionSet()
         self.server_dt = datetime.datetime(2016, 1, 1, 0, 0, 0)
-        self.server_tz = pytz.timezone('America/Chicago')
-        self.server_dt_aware = self.server_tz.localize(self.server_dt)
+        self.server_tz = zoneinfo.ZoneInfo('America/Chicago')
+        self.server_dt_aware = self.server_dt.replace(tzinfo=self.server_tz)
         self.server_tz_offset = -6
         self.utc_dt = self.server_dt - datetime.timedelta(hours=self.server_tz_offset)
 
@@ -175,8 +180,8 @@ class AppTodayConditionSetTests(TestCase):
         """
         self.condition_set = AppTodayConditionSet()
         self.server_dt = datetime.datetime(2016, 1, 1, 0, 0, 0)
-        self.server_tz = pytz.timezone('America/Chicago')
-        self.server_dt_aware = self.server_tz.localize(self.server_dt)
+        self.server_tz = zoneinfo.ZoneInfo('America/Chicago')
+        self.server_dt_aware = self.server_dt.replace(tzinfo=self.server_tz)
         self.server_tz_offset = -6
         self.app_to_server_tz_offset = datetime.timedelta(hours=1)
 
@@ -222,8 +227,8 @@ class ActiveTimezoneTodayConditionSetTests(TestCase):
         """
         self.condition_set = ActiveTimezoneTodayConditionSet()
         self.server_dt = datetime.datetime(2016, 1, 1, 0, 0, 0)
-        self.server_tz = pytz.timezone('America/Chicago')
-        self.server_dt_aware = self.server_tz.localize(self.server_dt)
+        self.server_tz = zoneinfo.ZoneInfo('America/Chicago')
+        self.server_dt_aware = self.server_dt.replace(tzinfo=self.server_tz)
         self.server_tz_offset = -6
         self.app_to_server_tz_offset = datetime.timedelta(hours=1)
         self.active_to_server_tz_offset = datetime.timedelta(hours=9)

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{38}-codestyle,
     py{38,39,310}-django{32,42}
+    py{310}-django{50}
 
 [testenv]
 setenv =
@@ -9,7 +10,9 @@ setenv =
 deps =
     django32: Django>=3.2,<4.0
     django42: Django>=4.2,<5.0
+    django50: Django>=5.0,<5.1
     -rrequirements.txt
+    py38: backports.zoneinfo==0.2.1
 commands = python runtests.py {posargs}
 
 


### PR DESCRIPTION
# What is the reason for this pull request?
This PR removes `pytz` from the repository.

# Code Review Instructions
## Acceptance tests
- Check that the dependency is removed in the whole repo.
- Run the test suite with `tox` and verify that it passes.

Tox results:
<img width="639" alt="image" src="https://github.com/roverdotcom/gargoyle/assets/17834064/3107eef9-5cf7-455c-9a1b-84da11d25540">
